### PR TITLE
fix(scatter): fix issue breaking chart scale transitions

### DIFF
--- a/src/models/scatter.js
+++ b/src/models/scatter.js
@@ -167,12 +167,15 @@ nv.models.scatter = function() {
                     yAbove.clamp(true).domain(yDomain || [1, min]).range(yRange || [availableHeight/2, 0]);
                     yBelow.clamp(true).domain(yDomain || [min, 1]).range(yRange || [availableHeight, availableHeight/2]);
                 } else {
-                        y.domain(yDomain || d3.extent(seriesData.map(function (d) { return d.y;}).concat(forceY)))
+                    y.clamp(true)
+                        .domain(yDomain || d3.extent(seriesData.map(function (d) {
+                            return d.y;
+                        }).concat(forceY)))
                         .range(yRange || [availableHeight, 0]);
-                        // Mirror Chart
-                        min = d3.min(seriesData.map(function (d) { return d.y;}).concat(forceY)) || 0;
-                        yAbove.domain(yDomain || [1, min]).range(yRange || [availableHeight/2, 0]);
-                        yBelow.domain(yDomain || [min, 1]).range(yRange || [availableHeight, availableHeight/2]);
+                    // Mirror Chart
+                    min = d3.min(seriesData.map(function (d) { return d.y; }).concat(forceY)) || 0;
+                    yAbove.clamp(true).domain(yDomain || [1, min]).range(yRange || [availableHeight/2, 0]);
+                    yBelow.clamp(true).domain(yDomain || [min, 1]).range(yRange || [availableHeight, availableHeight/2]);
                 }
 
             z   .domain(sizeDomain || d3.extent(seriesData.map(function(d) { return d.size }).concat(forceSize)))


### PR DESCRIPTION
A recent contribution to the upstream repo (commit fca4c2d) is affecting the transition of scales in **line charts**. See how the plot line transitions when switching from A to VA units:

![broken-nvd3-transition](https://user-images.githubusercontent.com/17259166/29733591-c7787724-89a2-11e7-8cd0-2abfb5d89ae5.gif)

The issue is only visible when transitioning from a data set with a small range to one with a large range. For other cases the issue may pass unnoticed.

It seems to me the block of the `else` statement I am modifying in this PR was never reached before commit fca4c2d. Now that this part of the code is executed it seems necessary to **clamp** the `y` axis to the height of the chart so transitions work the way the did before. See how the change in this PR makes the plot line transition just as it did before:

![fixed-nvd3-transition](https://user-images.githubusercontent.com/17259166/29733708-5763f75a-89a3-11e7-8afb-c62147dfd6b9.gif)

Visually it seems weird the transition for VA units happens from top to bottom when coming from A units but that's how nvd3 is meant to work, by transitioning a chart using the scale of the previous data set and the current one. This however could be fixed in wardenclyffe by destroying and rebuilding the chart whenever new data needs to be charted.